### PR TITLE
don't break down if there's only 1 branch point

### DIFF
--- a/loom/geometry.py
+++ b/loom/geometry.py
@@ -485,26 +485,29 @@ class SWDataBase(object):
                 )
                 z_list = bpzs + pctzs
                 z_r_list = map(float, [z.real for z in (bpzs + pctzs)])
-                min_x_distance =  min(
-                    [abs(x - y) for i, x in enumerate(z_r_list) 
-                     for y in z_r_list[i+1:]]
-                )
-                min_abs_distance =  min(
-                    [abs(x - y) for i, x in enumerate(z_list)
-                     for y in z_list[i+1:]]
-                )
+                if len(z_r_list) > 1:
+                    min_x_distance =  min(
+                        [abs(x - y) for i, x in enumerate(z_r_list)
+                         for y in z_r_list[i+1:]]
+                    )
+                    min_abs_distance =  min(
+                        [abs(x - y) for i, x in enumerate(z_list)
+                         for y in z_list[i+1:]]
+                    )
 
-                if min_x_distance > min_abs_distance / len(z_list):
-                    logging.info('All branch points and punctures '
-                                'are sufficiently separated horizontally.\n'
-                                'Will not rotate z-plane any more.\n')
-                    rotate_z_plane = False
+                    if min_x_distance > min_abs_distance / len(z_list):
+                        logging.info('All branch points and punctures '
+                                    'are sufficiently separated horizontally.\n'
+                                    'Will not rotate z-plane any more.\n')
+                        rotate_z_plane = False
+                    else:
+                        logging.info('Some branch points or punctures '
+                                    'are vertically aligned.\n'
+                                    'Need to rotate the z-plane.\n')
+                        n_r += 1
+                        z_plane_rotation *= z_r
                 else:
-                    logging.info('Some branch points or punctures '
-                                'are vertically aligned.\n'
-                                'Need to rotate the z-plane.\n')
-                    n_r += 1
-                    z_plane_rotation *= z_r
+                    rotate_z_plane = False
             
             if rotate_z_plane is False:
                 break

--- a/loom/trivialization.py
+++ b/loom/trivialization.py
@@ -234,7 +234,14 @@ class SWDataWithTrivialization(SWDataBase):
         # branch points/punctures.
         non_zero_distances = [x for x in all_distances
                               if abs(x) > self.accuracy]
-        self.min_distance = min(non_zero_distances)
+        if n_critical_loci == 1:
+            # hacky way of dealing with special case of just
+            # one branch point
+            self.min_distance = 0.1
+            self.base_point = center - 0.2j
+        else:
+            self.min_distance = min(non_zero_distances)
+
         #print 'all points {}'.format(all_points_z)
         #print 'all distances: {}'.format(non_zero_distances)
         #print self.min_distance


### PR DESCRIPTION
This is a trivial fix for a trivial bug: things would break down if there was only 1 branch point.
