### PR TITLE
allow differential parameters to be empty

### DIFF
--- a/loom/misc.py
+++ b/loom/misc.py
@@ -220,6 +220,8 @@ def parse_sym_dict_str(string):
     """
     result = []
     for k_v_str in string.lstrip('{').rstrip('}').split(','):
+        if not k_v_str.strip():
+            continue
         item = k_v_str.split(':')
         if len(item) != 2:
             item = k_v_str.split('=')


### PR DESCRIPTION
I don't usually use the "differential parameters" -- I just write exactly the differentials I want. But the current master throws a syntax error if I set the differential parameters to an empty list. This branch fixes that.
